### PR TITLE
Add build definitions for SDL Image.

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1,0 +1,31 @@
+project('sdl2-image', 'c')
+
+feature_args = ['-DLOAD_BMP', '-DLOAD_PNG', '-DLOAD_JPG', '-DLOAD_TIF']
+sdl2_dep = dependency('sdl2')
+png_dep = dependency('libpng')
+jpeg_dep = dependency('libjpeg')
+tif_dep = dependency('libtiff-4')
+
+sdl2_image_lib = library('sdl2image',
+  'IMG.c',
+  'IMG_bmp.c',
+  'IMG_gif.c',
+  'IMG_jpg.c',
+  'IMG_lbm.c',
+  'IMG_pcx.c',
+  'IMG_png.c',
+  'IMG_pnm.c',
+  'IMG_svg.c',
+  'IMG_tga.c',
+  'IMG_tif.c',
+  'IMG_webp.c',
+  'IMG_WIC.c',
+  'IMG_xcf.c',
+  'IMG_xpm.c',
+  'IMG_xv.c',
+  'IMG_xxx.c',
+  c_args: feature_args,
+  dependencies: [png_dep, jpeg_dep, tif_dep, sdl2_dep])
+
+sdl2_image_dep = declare_dependency(include_directories: '.',
+  link_with: sdl2_image_lib)

--- a/upstream.wrap
+++ b/upstream.wrap
@@ -1,0 +1,9 @@
+[wrap-file]
+directory = SDL2_image-2.0.5
+
+source_url = https://www.libsdl.org/projects/SDL_image/release/SDL2_image-2.0.5.tar.gz
+source_filename = SDL2_image-2.0.5.tar.gz
+source_hash = bdd5f6e026682f7d7e1be0b6051b209da2f402a2dd8bd1c4bd9c25ad263108d0
+
+[provide]
+sdl2_image = sdl2_image_dep


### PR DESCRIPTION
Requires MRs to libpng, libjpg, libtiff and zlib to be merged first.